### PR TITLE
getSingleImpl: don't check whether a map value is zero

### DIFF
--- a/pointer.go
+++ b/pointer.go
@@ -135,7 +135,7 @@ func getSingleImpl(node interface{}, decodedToken string, nameProvider *swag.Nam
 		kv := reflect.ValueOf(decodedToken)
 		mv := rValue.MapIndex(kv)
 
-		if mv.IsValid() && !swag.IsZero(mv) {
+		if mv.IsValid() {
 			return mv.Interface(), kind, nil
 		}
 		return nil, kind, fmt.Errorf("object has no key %q", decodedToken)


### PR DESCRIPTION
The code that checked whether a map value is zero was wrong.
It passed the reflect.Value itself, which before Go 1.13 was never zero.
In Go 1.13 this changed, as reflect.Value got an IsZero method,
which reports whether the value stored in the reflect.Value is zero.
Checking that causes tests in go-openapi/spec to fail.

Fixes go-openapi/spec#99

Signed-off-by: Ian Lance Taylor <iant@golang.org>