### PR TITLE
ci: configured auto-approve & auto-merge for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,11 +1,57 @@
 version: 2
 updates:
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  open-pull-requests-limit: 10
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    open-pull-requests-limit: 2          # <- default is 5
+    groups:                              # <- group all github actions updates in a single PR
+      # 1. development-dependencies are auto-merged
+      development-dependencies:
+        dependency-type: development
+        patterns:
+          - '*'
+
+  - package-ecosystem: "gomod"
+    # We define 4 groups of dependencies to regroup update pull requests:
+    # - development (e.g. test dependencies)
+    # - go-openapi updates
+    # - golang.org (e.g. golang.org/x/... packages)
+    # - other dependencies (direct or indirect)
+    #
+    # * All groups are checked once a week and each produce at most 1 PR.
+    # * All dependabot PRs are auto-approved
+    #
+    # Auto-merging policy, when requirements are met:
+    # 1. development-dependencies are auto-merged
+    # 2. golang.org-dependencies are auto-merged
+    # 3. go-openapi patch updates are auto-merged. Minor/major version updates require a manual merge.
+    # 4. other dependencies require a manual merge
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+    open-pull-requests-limit: 4
+    groups:
+      development-dependencies:
+        dependency-type: development
+        patterns:
+          - "github.com/stretchr/testify"
+
+      golang.org-dependencies:
+        dependency-type: production
+        patterns:
+          - "golang.org/*"
+
+      go-openapi-dependencies:
+        dependency-type: production
+        patterns:
+          - "github.com/go-openapi/*"
+
+      other-dependencies:
+        dependency-type: production
+        exclude-patterns:
+          - "github.com/go-openapi/*"
+          - "github.com/stretchr/testify"
+          - "golang.org/*"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,43 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+
+      - name: Auto-approve all dependabot PRs
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Auto-merge dependabot PRs for development dependencies
+        if: contains(steps.metadata.outputs.dependency-group, 'development-dependencies')
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Auto-merge dependabot PRs for go-openapi patches
+        if: contains(steps.metadata.outputs.dependency-group, 'go-openapi-dependencies') && steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Auto-merge dependabot PRs for golang.org updates
+        if: contains(steps.metadata.outputs.dependency-group, 'golang.org-dependencies')
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+


### PR DESCRIPTION
* All groups are checked once a week and each produce at most 1 PR.
* All dependabot PRs are auto-approved

Caveats:
* this requires auto-merge to be enabled in the repository settings
  [done]
* this requires all desired tests to be required in the branch
  protection rule [done]

- package-ecosystem: "github-actions"
    1. development-dependencies are auto-merged

- package-ecosystem: "gomod"
     We define 4 groups of dependencies to regroup update pull requests:
     - development (e.g. test dependencies)
     - go-openapi updates
     - golang.org (e.g. golang.org/x/... packages)
     - other dependencies (direct or indirect)
    
    
     Auto-merging policy, when requirements are met:
     1. development-dependencies are auto-merged
     2. golang.org-dependencies are auto-merged
     3. go-openapi patch updates are auto-merged. Minor/major version updates require a manual merge.
     4. other dependencies require a manual merge

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>