### PR TITLE
chore: bump go directive to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,4 @@ require (
 	github.com/go-openapi/testify/v2 v2.4.1
 )
 
-go 1.24.0
+go 1.25.0


### PR DESCRIPTION
## Summary

- Update all `go.mod` (and `go.work` where applicable) to require `go 1.25.0`
- Run `go mod tidy` / `go work sync` to update checksums

## Test plan

- [ ] CI passes on all platforms (ubuntu, macos, windows) x (stable, oldstable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)