### PR TITLE
fix(errors): correct error message for invalid JSON pointer start

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -16,7 +16,7 @@ const (
 	ErrPointer pointerError = "JSON pointer error"
 
 	// ErrInvalidStart states that a JSON pointer must start with a separator ("/").
-	ErrInvalidStart pointerError = `JSON pointer must be empty or start with a "` + pointerSeparator
+	ErrInvalidStart pointerError = `JSON pointer must be empty or start with a "` + pointerSeparator + `"`
 
 	// ErrUnsupportedValueType indicates that a value of the wrong type is being set.
 	ErrUnsupportedValueType pointerError = "only structs, pointers, maps and slices are supported for setting values"

--- a/pointer_test.go
+++ b/pointer_test.go
@@ -444,6 +444,8 @@ func TestOtherThings(t *testing.T) {
 	t.Run("single string pointer should be valid", func(t *testing.T) {
 		_, err := New("abc")
 		require.Error(t, err)
+		assert.EqualError(t, err, `JSON pointer must be empty or start with a "/"
+JSON pointer error`)
 	})
 
 	t.Run("empty string pointer should be valid", func(t *testing.T) {


### PR DESCRIPTION
## Change type

🔧 Bug fix

## Short description

Append missing `"` to the `ErrInvalidStart` message.

## Checklist

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
