### PR TITLE
ci: post README announcements to discord + bump ci-workflows to v0.4.0

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,5 +11,5 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: go-openapi/ci-workflows/.github/workflows/auto-merge.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # v0.3.5
+    uses: go-openapi/ci-workflows/.github/workflows/auto-merge.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     secrets: inherit

--- a/.github/workflows/bump-release.yml
+++ b/.github/workflows/bump-release.yml
@@ -30,7 +30,7 @@ jobs:
   bump-release:
     permissions:
       contents: write
-    uses: go-openapi/ci-workflows/.github/workflows/bump-release.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # v0.3.5
+    uses: go-openapi/ci-workflows/.github/workflows/bump-release.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     with:
       bump-type: ${{ inputs.bump-type }}
       tag-message-title: ${{ inputs.tag-message-title }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,5 +18,5 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: go-openapi/ci-workflows/.github/workflows/codeql.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # v0.3.5
+    uses: go-openapi/ci-workflows/.github/workflows/codeql.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     secrets: inherit

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -14,5 +14,5 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    uses: go-openapi/ci-workflows/.github/workflows/contributors.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # v0.3.5
+    uses: go-openapi/ci-workflows/.github/workflows/contributors.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     secrets: inherit

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -13,5 +13,5 @@ on:
 
 jobs:
   test:
-    uses: go-openapi/ci-workflows/.github/workflows/go-test.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # v0.3.5
+    uses: go-openapi/ci-workflows/.github/workflows/go-test.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     secrets: inherit

--- a/.github/workflows/monitor-bot-pr.yml
+++ b/.github/workflows/monitor-bot-pr.yml
@@ -14,5 +14,5 @@ jobs:
       contents: write
       pull-requests: write
       statuses: read
-    uses: go-openapi/ci-workflows/.github/workflows/monitor-bot-pr.yml@2e57e83146e049b5dfb8116ba16a09b2da27b3c5 # v0.3.3
+    uses: go-openapi/ci-workflows/.github/workflows/monitor-bot-pr.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     secrets: inherit

--- a/.github/workflows/scanner.yml
+++ b/.github/workflows/scanner.yml
@@ -15,5 +15,5 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: go-openapi/ci-workflows/.github/workflows/scanner.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # V0.1.1
+    uses: go-openapi/ci-workflows/.github/workflows/scanner.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     secrets: inherit

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create release
     permissions:
       contents: write
-    uses: go-openapi/ci-workflows/.github/workflows/release.yml@f00f5763ddb0c59105de5f565da8cac323fce2bf # v0.3.5
+    uses: go-openapi/ci-workflows/.github/workflows/release.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
     with:
       tag: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/webhook-announcements.yml
+++ b/.github/workflows/webhook-announcements.yml
@@ -1,0 +1,60 @@
+name: Webhook Announcements
+
+# invoke the common webhook-announcements workflow, scanning README.
+#
+# Two modes:
+#
+#   * push: diff on "## Announcements" section exercises the
+#     real before..after detection and post to discord channel.
+#
+#   * workflow_dispatch: a manual live run. Optionally provide an arbitrary webhook URL and
+#     it POSTs for real. By default it diffs against the git empty tree, so every
+#     announcement currently in the fixture is posted — no need to craft a diff.
+#
+# NOTE: the webhook URL you type is a workflow_dispatch input and is therefore
+# visible in the run's UI/logs. Use a throwaway test webhook (and/or rotate it
+# afterwards), not the production go-openapi webhook.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'README.md'
+
+  workflow_dispatch:
+    inputs:
+      webhook-url:
+        description: |
+          Webhook URL to POST to (e.g. a test Discord channel webhook).
+          Visible in run logs — use a throwaway webhook.
+        type: string
+        default: ''
+      compare-base:
+        description: |
+          Git ref to diff the fixture against. The default empty-tree SHA posts
+          every announcement currently in the fixture.
+        type: string
+        default: ""
+      dry-run:
+        description: |
+          Print payloads instead of posting.
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+        default: 'false'
+
+jobs:
+  announce:
+    uses: go-openapi/ci-workflows/.github/workflows/webhook-announcements.yml@af4c93f45481ea7d24ac2a9858272cc03daf424e # v0.4.0
+    with:
+      scanned-markdown: README.md
+      # On push: normal before..after diff (empty
+      # compare-base). On dispatch: honor the provided inputs.
+      dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || 'false' }}
+      compare-base: ${{ github.event_name == 'workflow_dispatch' && inputs.compare-base || '' }}
+    secrets: inherit


### PR DESCRIPTION
## What

- Add `.github/workflows/webhook-announcements.yml`, mirroring the workflow already live in [go-openapi/testify](https://github.com/go-openapi/testify). On pushes to `master` that touch `README.md`, new entries under the `## Announcements` section are detected and posted to the go-openapi Discord channel.
- Bump all `go-openapi/ci-workflows` shared-workflow pins to **v0.4.0** (`af4c93f45481ea7d24ac2a9858272cc03daf424e`).

## Why

Generalizes the announcements automation across all go-openapi repos and brings the shared-workflow pins up to the current release. Secrets are org-wide, so no per-repo configuration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)